### PR TITLE
Fix ROTest under Mac M1 and include QToolbar

### DIFF
--- a/src/plugins/diffscope/coreplugin/Window/IProjectWindow.h
+++ b/src/plugins/diffscope/coreplugin/Window/IProjectWindow.h
@@ -4,6 +4,7 @@
 #include <CDockFrame.h>
 
 #include <QAbstractButton>
+#include <QToolBar>
 
 #include "Document/DspxDocument.h"
 #include "ICoreWindow.h"

--- a/src/tests/simple/QtROTest/client/CommunicationHelper.cpp
+++ b/src/tests/simple/QtROTest/client/CommunicationHelper.cpp
@@ -72,3 +72,5 @@ Awaiter::Awaiter(): Awaiter(new AwaiterPrivate) {
 Awaiter::Awaiter(AwaiterPrivate *d): d_ptr(d) {
     d->q_ptr = this;
 }
+Awaiter::~Awaiter() {
+}

--- a/src/tests/simple/QtROTest/client/CommunicationHelper.h
+++ b/src/tests/simple/QtROTest/client/CommunicationHelper.h
@@ -20,6 +20,7 @@ class Awaiter: public QObject {
     friend class CommunicationHelper;
 public:
     explicit Awaiter();
+    ~Awaiter();
     Q_INVOKABLE void call(std::function<QVariant()> fx);
     Q_INVOKABLE void callBySignal(std::function<void()> fx);
     void wait();


### PR DESCRIPTION
Qt's scoped pointer complains about an incomplete class if no destructor is provided.
Under Qt 5.15.10, it looks like to use QToolbar, it needs to be included.